### PR TITLE
Unity5.2に対応

### DIFF
--- a/Assets/VertexEffects/Scripts/BoxOutline.cs
+++ b/Assets/VertexEffects/Scripts/BoxOutline.cs
@@ -41,7 +41,21 @@ public class BoxOutline : ModifiedShadow
         }
     }
 
-    public override void ModifyVertices(List<UIVertex> verts)
+    public override void ModifyMesh(VertexHelper vh)
+    {
+        if (!this.IsActive())
+            return;
+
+        List<UIVertex> list = new List<UIVertex>();
+        vh.GetUIVertexStream(list);
+
+        ModifyVertices(list);
+
+        vh.Clear();
+        vh.AddUIVertexTriangleStream(list);
+    }
+
+    public void ModifyVertices(List<UIVertex> verts)
     {
         if (!IsActive())
             return;

--- a/Assets/VertexEffects/Scripts/CircleOutline.cs
+++ b/Assets/VertexEffects/Scripts/CircleOutline.cs
@@ -65,7 +65,21 @@ public class CircleOutline : ModifiedShadow
     }
 
 
-    public override void ModifyVertices(List<UIVertex> verts)
+    public override void ModifyMesh(VertexHelper vh)
+    {
+        if (!this.IsActive())
+            return;
+
+        List<UIVertex> list = new List<UIVertex>();
+        vh.GetUIVertexStream(list);
+
+        ModifyVertices(list);
+
+        vh.Clear();
+        vh.AddUIVertexTriangleStream(list);
+    }
+
+    public void ModifyVertices(List<UIVertex> verts)
     {
         if (!IsActive())
             return;

--- a/Assets/VertexEffects/Scripts/Outline8.cs
+++ b/Assets/VertexEffects/Scripts/Outline8.cs
@@ -4,7 +4,21 @@ using System.Collections.Generic;
 
 public class Outline8 : ModifiedShadow
 {
-    public override void ModifyVertices(List<UIVertex> verts)
+    public override void ModifyMesh(VertexHelper vh)
+    {
+        if (!this.IsActive())
+            return;
+
+        List<UIVertex> list = new List<UIVertex>();
+        vh.GetUIVertexStream(list);
+
+        ModifyVertices(list);
+
+        vh.Clear();
+        vh.AddUIVertexTriangleStream(list);
+    }
+
+    public void ModifyVertices(List<UIVertex> verts)
     {
         if (!IsActive())
             return;


### PR DESCRIPTION
Unity5.2ではModifyVerticesがオーバーライドできなくなったようなので、
http://forum.unity3d.com/threads/unity-5-2-ui-performance-seems-much-worse.353650/
を参考に、ModifyMeshをオーバーライドしてその内部で既存の処理を呼ぶ形にしました。
