### PR TITLE
Implement object pooling to avoid memory leaks

### DIFF
--- a/Assets/VertexEffects/Scripts/BoxOutline.cs
+++ b/Assets/VertexEffects/Scripts/BoxOutline.cs
@@ -46,9 +46,9 @@ public class BoxOutline : ModifiedShadow
         if (!IsActive())
             return;
 
-		var neededCapacity = verts.Count * (m_halfSampleCountX * 2 + 1) * (m_halfSampleCountY * 2 + 1);
-	    if (verts.Capacity < neededCapacity)
-        	verts.Capacity = neededCapacity;
+        var neededCapacity = verts.Count * (m_halfSampleCountX * 2 + 1) * (m_halfSampleCountY * 2 + 1);
+        if (verts.Capacity < neededCapacity)
+            verts.Capacity = neededCapacity;
 
         var original = verts.Count;
         var count = 0;

--- a/Assets/VertexEffects/Scripts/BoxOutline.cs
+++ b/Assets/VertexEffects/Scripts/BoxOutline.cs
@@ -46,7 +46,10 @@ public class BoxOutline : ModifiedShadow
         if (!IsActive())
             return;
 
-        verts.Capacity = verts.Count * (m_halfSampleCountX * 2 + 1) * (m_halfSampleCountY * 2 + 1);
+		var neededCapacity = verts.Count * (m_halfSampleCountX * 2 + 1) * (m_halfSampleCountY * 2 + 1);
+	    if (verts.Capacity < neededCapacity)
+        	verts.Capacity = neededCapacity;
+
         var original = verts.Count;
         var count = 0;
         var dx = effectDistance.x / m_halfSampleCountX;
@@ -58,7 +61,7 @@ public class BoxOutline : ModifiedShadow
                 if (!(x == 0 && y == 0))
                 {
                     var next = count + original;
-                    ApplyShadow(verts, effectColor, count, next, dx * x, dy * y);
+                    ApplyShadowZeroAlloc(verts, effectColor, count, next, dx * x, dy * y);
                     count = next;
                 }
             }

--- a/Assets/VertexEffects/Scripts/CircleOutline.cs
+++ b/Assets/VertexEffects/Scripts/CircleOutline.cs
@@ -89,7 +89,11 @@ public class CircleOutline : ModifiedShadow
             for (int j = 0; j < sampleCount; j++)
             {
                 var next = count + original;
+#if UNITY_5_1 || UNITY_5_2 || UNITY_5_3
+                ApplyShadow(verts, effectColor, count, next, rx * Mathf.Cos(rad), ry * Mathf.Sin(rad));
+#else
                 ApplyShadowZeroAlloc(verts, effectColor, count, next, rx * Mathf.Cos(rad), ry * Mathf.Sin(rad));
+#endif
                 count = next;
                 rad += radStep;
             }

--- a/Assets/VertexEffects/Scripts/CircleOutline.cs
+++ b/Assets/VertexEffects/Scripts/CircleOutline.cs
@@ -72,7 +72,9 @@ public class CircleOutline : ModifiedShadow
             return;
 
         var total = (m_firstSample * 2 + m_sampleIncrement * (m_circleCount - 1)) * m_circleCount / 2;
-        verts.Capacity = verts.Count * (total + 1);
+		var neededCapacity = verts.Count * (total + 1);
+	    if (verts.Capacity < neededCapacity)
+        	verts.Capacity = neededCapacity;
         var original = verts.Count;
         var count = 0;
         var sampleCount = m_firstSample;
@@ -87,7 +89,7 @@ public class CircleOutline : ModifiedShadow
             for (int j = 0; j < sampleCount; j++)
             {
                 var next = count + original;
-                ApplyShadow(verts, effectColor, count, next, rx * Mathf.Cos(rad), ry * Mathf.Sin(rad));
+                ApplyShadowZeroAlloc(verts, effectColor, count, next, rx * Mathf.Cos(rad), ry * Mathf.Sin(rad));
                 count = next;
                 rad += radStep;
             }

--- a/Assets/VertexEffects/Scripts/CircleOutline.cs
+++ b/Assets/VertexEffects/Scripts/CircleOutline.cs
@@ -72,9 +72,9 @@ public class CircleOutline : ModifiedShadow
             return;
 
         var total = (m_firstSample * 2 + m_sampleIncrement * (m_circleCount - 1)) * m_circleCount / 2;
-		var neededCapacity = verts.Count * (total + 1);
-	    if (verts.Capacity < neededCapacity)
-        	verts.Capacity = neededCapacity;
+        var neededCapacity = verts.Count * (total + 1);
+        if (verts.Capacity < neededCapacity)
+            verts.Capacity = neededCapacity;
         var original = verts.Count;
         var count = 0;
         var sampleCount = m_firstSample;

--- a/Assets/VertexEffects/Scripts/ListPool.cs
+++ b/Assets/VertexEffects/Scripts/ListPool.cs
@@ -4,16 +4,16 @@ using UnityEngine;
 
 static class ListPool<T>
 {
-        // Object pool to avoid allocations.
- 	private static readonly ObjectPool<List<T>> s_ListPool = new ObjectPool<List<T>>(null, l => l.Clear());
+    // Object pool to avoid allocations.
+    private static readonly ObjectPool<List<T>> s_ListPool = new ObjectPool<List<T>>(null, l => l.Clear());
 
-	public static List<T> Get()
-	{
-		return s_ListPool.Get();
-	}
+    public static List<T> Get()
+    {
+        return s_ListPool.Get();
+    }
 
-	public static void Release(List<T> toRelease)
-	{
-		s_ListPool.Release(toRelease);
-	}
+    public static void Release(List<T> toRelease)
+    {
+        s_ListPool.Release(toRelease);
+    }
 }

--- a/Assets/VertexEffects/Scripts/ListPool.cs
+++ b/Assets/VertexEffects/Scripts/ListPool.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+static class ListPool<T>
+{
+        // Object pool to avoid allocations.
+ 	private static readonly ObjectPool<List<T>> s_ListPool = new ObjectPool<List<T>>(null, l => l.Clear());
+
+	public static List<T> Get()
+	{
+		return s_ListPool.Get();
+	}
+
+	public static void Release(List<T> toRelease)
+	{
+		s_ListPool.Release(toRelease);
+	}
+}

--- a/Assets/VertexEffects/Scripts/ListPool.cs.meta
+++ b/Assets/VertexEffects/Scripts/ListPool.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: de62fb65cac6142dd89532fdc9fa227e
+timeCreated: 1465598379
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VertexEffects/Scripts/ModifiedShadow.cs
+++ b/Assets/VertexEffects/Scripts/ModifiedShadow.cs
@@ -58,17 +58,17 @@ public class ModifiedShadow : Shadow
     {
         if (!this.IsActive())
             return;
-        
-		var list = ListPool<UIVertex>.Get();
+
+        var list = ListPool<UIVertex>.Get();
         vh.GetUIVertexStream(list);
-        
+
         ModifyVertices(list);
 
 #if UNITY_5_2_1pX || UNITY_5_3
         vh.Clear();
 #endif
         vh.AddUIVertexTriangleStream(list);
-		ListPool<UIVertex>.Release(list);
+        ListPool<UIVertex>.Release(list);
     }
 
     public virtual void ModifyVertices(List<UIVertex> verts)

--- a/Assets/VertexEffects/Scripts/ModifiedShadow.cs
+++ b/Assets/VertexEffects/Scripts/ModifiedShadow.cs
@@ -59,7 +59,7 @@ public class ModifiedShadow : Shadow
         if (!this.IsActive())
             return;
         
-        List<UIVertex> list = new List<UIVertex>();
+		var list = ListPool<UIVertex>.Get();
         vh.GetUIVertexStream(list);
         
         ModifyVertices(list);
@@ -68,6 +68,7 @@ public class ModifiedShadow : Shadow
         vh.Clear();
 #endif
         vh.AddUIVertexTriangleStream(list);
+		ListPool<UIVertex>.Release(list);
     }
 
     public virtual void ModifyVertices(List<UIVertex> verts)

--- a/Assets/VertexEffects/Scripts/ObjectPool.cs
+++ b/Assets/VertexEffects/Scripts/ObjectPool.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class ObjectPool<T> where T : new()
+{
+    private readonly Stack<T> m_Stack = new Stack<T>();
+    private readonly UnityAction<T> m_ActionOnGet;
+    private readonly UnityAction<T> m_ActionOnRelease;
+
+    public int countAll { get; private set; }
+    public int countActive { get { return countAll - countInactive; } }
+    public int countInactive { get { return m_Stack.Count; } }
+
+    public ObjectPool(UnityAction<T> actionOnGet, UnityAction<T> actionOnRelease)
+    {
+        m_ActionOnGet = actionOnGet;
+        m_ActionOnRelease = actionOnRelease;
+    }
+
+    public T Get()
+    {
+        T element;
+        if (m_Stack.Count == 0)
+        {
+            element = new T();
+            countAll++;
+        }
+        else
+        {
+            element = m_Stack.Pop();
+        }
+        if (m_ActionOnGet != null)
+            m_ActionOnGet(element);
+        return element;
+    }
+
+    public void Release(T element)
+    {
+        if (m_Stack.Count > 0 && ReferenceEquals(m_Stack.Peek(), element))
+            Debug.LogError("Internal error. Trying to destroy object that is already released to pool.");
+        if (m_ActionOnRelease != null)
+            m_ActionOnRelease(element);
+        m_Stack.Push(element);
+    }
+}

--- a/Assets/VertexEffects/Scripts/ObjectPool.cs.meta
+++ b/Assets/VertexEffects/Scripts/ObjectPool.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 58383e59ca8434c3db920b1d970e83c1
+timeCreated: 1465598472
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VertexEffects/Scripts/Outline8.cs
+++ b/Assets/VertexEffects/Scripts/Outline8.cs
@@ -9,7 +9,10 @@ public class Outline8 : ModifiedShadow
         if (!IsActive())
             return;
 
-        verts.Capacity = verts.Count * 9;
+		var neededCapacity = verts.Count * 9;
+	    if (verts.Capacity < neededCapacity)
+        	verts.Capacity = neededCapacity;
+
         var original = verts.Count;
         var count = 0;
         for (int x = -1; x <= 1; x++)
@@ -19,7 +22,7 @@ public class Outline8 : ModifiedShadow
                 if (!(x == 0 && y == 0))
                 {
                     var next = count + original;
-                    ApplyShadow(verts, effectColor, count, next, effectDistance.x * x, effectDistance.y * y);
+                    ApplyShadowZeroAlloc(verts, effectColor, count, next, effectDistance.x * x, effectDistance.y * y);
                     count = next;
                 }
             }

--- a/Assets/VertexEffects/Scripts/Outline8.cs
+++ b/Assets/VertexEffects/Scripts/Outline8.cs
@@ -9,9 +9,9 @@ public class Outline8 : ModifiedShadow
         if (!IsActive())
             return;
 
-		var neededCapacity = verts.Count * 9;
-	    if (verts.Capacity < neededCapacity)
-        	verts.Capacity = neededCapacity;
+        var neededCapacity = verts.Count * 9;
+        if (verts.Capacity < neededCapacity)
+            verts.Capacity = neededCapacity;
 
         var original = verts.Count;
         var count = 0;


### PR DESCRIPTION
Taking a look to the Unity Profiler, I noticed some memory leaks when using these outline effects.

I implemented object pooling, using the same approach Unity did in its UI

https://bitbucket.org/Unity-Technologies/ui

Hope it helps ;)
